### PR TITLE
fix: Update findSelectedInput to ignore 'goog-control' class

### DIFF
--- a/wzk/ui/grid/BulkChange.coffee
+++ b/wzk/ui/grid/BulkChange.coffee
@@ -256,7 +256,7 @@ class wzk.ui.grid.BulkChange
     @param {Element} field
   ###
   findSelectedInput: (field) ->
-    return @dom.one('input, select, textarea', field)
+    return @dom.one('input:not(.goog-control), select, textarea', field)
 
   ###*
     @protected


### PR DESCRIPTION
- Modified the findSelectedInput function to exclude elements with the 'goog-control' class
- Ensured that only relevant input, select, and textarea elements are selected within the specified field